### PR TITLE
add Strava link and logo to menu, all social menu open in new windows, added footer to benefits page, fixed the last paragraph gap

### DIFF
--- a/benefits/index.html
+++ b/benefits/index.html
@@ -113,4 +113,6 @@
 </main>
 </body>
 
-</html>
+<footer>
+    <small>&copy; Portsmouth Joggers 2025</small>
+</footer>

--- a/menu.json
+++ b/menu.json
@@ -42,17 +42,26 @@
       {
         "text": "Instagram",
         "href": "https://www.instagram.com/portsmouthjoggers/",
-        "icon": "/x/logo-ig.svg"
+        "icon": "/x/logo-ig.svg",
+        "target": "_blank"
       },
       {
         "text": "Facebook",
         "href": "https://www.facebook.com/groups/129643517173916",
-        "icon": "/x/logo-fb.svg"
+        "icon": "/x/logo-fb.svg",
+        "target": "_blank"
       },
       {
         "text": "Members",
         "href": "https://www.facebook.com/groups/786928831462848",
-        "icon": "/x/logo-fb.svg"
+        "icon": "/x/logo-fb.svg",
+        "target": "_blank"
+      },
+      {
+      "text": "Strava",
+      "href": "https://www.strava.com/clubs/portsmouthjoggers",
+      "icon": "/x/logo-strava.svg",
+      "target": "_blank"
       }
     ]
   }

--- a/x/logo-strava.svg
+++ b/x/logo-strava.svg
@@ -1,0 +1,1 @@
+<svg width="24px" height="24px" viewBox="0 0 24 24" role="img" xmlns="http://www.w3.org/2000/svg"><title>Strava icon</title><path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/></svg>

--- a/x/menu.js
+++ b/x/menu.js
@@ -50,6 +50,14 @@ function renderMenu(data) {
       const anchor = document.createElement('a');
       anchor.textContent = item.text;
       anchor.setAttribute('href', item.href);
+
+      // Check if 'target' exists in the item and apply it
+      if (item.target) {
+        anchor.target = item.target;  // Add target to open in a new tab
+      } else {
+        anchor.target = '_self';  // Default to open in the same tab
+      }
+      
       if (item.icon) {
         const img = document.createElement('img');
         img.setAttribute('src', item.icon);

--- a/x/style.css
+++ b/x/style.css
@@ -210,7 +210,7 @@ main a {
    * a section
    */
 main :is(article, section:last-child)>p:last-child:not(p:first-child) {
-    text-wrap: balance;
+    /* text-wrap: balance; */  /* Removed to fix last paragraph gaps */
 }
 
 


### PR DESCRIPTION
Strava added to menu.
<img width="172" alt="image" src="https://github.com/user-attachments/assets/7f58429c-8c0d-4e23-a53a-07a6a31b46f5" />
Plus all social media links now open to a new browser window. 

Footer missing from Benefits page:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/01bb8654-0d75-4714-b215-378a725795ae" />
Now added:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/9a58648c-b9ec-4cd5-93a5-343f133ec207" />

Gaps to right of last paragraphs. Examples:
<img width="742" alt="image" src="https://github.com/user-attachments/assets/23e28b99-1a7b-499e-9b39-073da121729e" />
and
<img width="742" alt="image" src="https://github.com/user-attachments/assets/3b91588e-9004-4835-bebc-2a05f7bce404" />

Now fixed:
<img width="742" alt="image" src="https://github.com/user-attachments/assets/a3a1b671-967c-42da-8636-945430c353d1" />
and 
<img width="742" alt="image" src="https://github.com/user-attachments/assets/5ce73f4b-239e-4712-9ae8-de08b2c0f8ff" />


