### PR TITLE
Add AGM agenda to Member Hub main page

### DIFF
--- a/members/agm2025.html
+++ b/members/agm2025.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/x/all.css">
+<link rel="icon" href="/x/logo-pj.svg">
+<link rel="manifest" href="/manifest.json">
+<script src="/x/menu.js" type="module"></script>
+
+<title>AGM 2025 Agenda</title>
+<meta name="description" content="Agenda for the 2025 AGM.">
+
+<style>
+  nav {
+    ol {
+      li {
+        font-weight: bold;
+        margin-top: 1em;
+
+        * {
+          font-weight: normal;
+        }
+      }
+    }
+  }
+
+  blockquote {
+    padding: 0;
+    font-style: italic;
+  }
+
+  blockquote:before {
+    font-size: 100%;
+    content: "\0022";
+    margin-left: -0.7rem;
+  }
+
+  .highlight {
+    background-color: var(--col1light);
+    border-radius: 0.5rem;
+    ;
+  }
+</style>
+
+<header>
+  <img id="masthead" src="/x/logo-pj.svg" alt="Portsmouth Joggers Logo" width="138" height="138">
+  <p class=banner>Portsmouth Joggers
+  <p class=tagline>Running Around Pompey Since 1976.
+</header>
+
+<main>
+  <article>
+    <h1>2025 AGM Agenda</h1>
+    <time datetime="2025-04-22 19:00">7.00 pm, 22nd April 2025</time>
+    <address>Portsmouth Rugby Football Club, Norway Road, Portsmouth PO3 5EP ( <a href="https://maps.app.goo.gl/uFxSTFnDZAzcX4Ky5">map</a> )</address>
+
+    <nav>
+      <h2>Agenda</h2>
+      <ol>
+        <li>Welcome address from the Chairperson</li>
+        <li>Approval of minutes of previous AGM</li>
+        <li>Chairperson's Report</li>
+        <li>Treasurer's Report and Accounts</li>
+        <li>Club 50th Birthday Celebrations sub committee</li>
+        <li>Motions
+
+          <ol>
+            <li id=item1>Nomination for Life Membership to be awarded to Tony Conway. Nominated by Davina Glading, seconded by
+              Steve Wooldridge and endorsed by the Committee.
+              <blockquote>
+                Tony has been a PJC member since Nelson's parrot was an egg, he is a long time member with unbroken
+                tenure. In this time, Tony has not only represented the club internationally, but nationally, and in leagues
+                also. Tony has raced in ultra distance events, yet also been a real champion of C25K folks starting out – and
+                everything in between.
+                <p>Tony is the race organiser of the Pebbledash every year, which unites runners and walkers after the Christmas
+                  excesses for a brutal leg stretch. The medals are, in themselves, a challenge for Tony to supply, this must take
+                  some time.
+                <p>Tony also motivated the Malta cohorts for several years with the training plans and accountability, all to
+                  make sure that the PJC teams were well trained and ready to run the half, or full marathons. A wonderful
+                  supporter (and runner) for Malta over the years.
+                <p>Tony also is a wonderful support for the Ladies' 5 training runs, with whooping people around the course in
+                  the months leading up to the actual race. He loops back and picks up the slower runners also with beautiful
+                  enthusiasm and non-patronising encouragement.
+                <p>There are also the all-club runs where Tony unites the entire PJC community, including the Remembrance
+                  run. These are great fun, and all levels encompassing. Tony *never* says anyone is “slow or excludes anyone
+                  – he is just the epitome of PJC ethos. Then, of course Tony is a Group Leader for the “mad-as-a-box-of-frogs
+                  fast group.
+              </blockquote>
+
+            </li>
+
+            <li>Charity Request (£250) from Russ Tullett for Sophies Legacy, they do amazing work at the hospital to make
+              parents and children's hospital stays a little more tolerable. It's a charity he ran WD200 for last December.
+            </li>
+
+
+            <li>Charity Request (£250) from Helen Sumbler for Purbrook Infant school PTA (registered charity) to sponsor a
+              colour run we are planning. The donation would cover the cost of each child receiving a medal. And may get
+              them running (would also put a special mention of Portsmouth Joggers on poster etc)</li>
+
+            <li>Charity Request (£250) from John Shepherd for Creative Advances who are day support and outreach
+              services, for adults with learning disabilities and autism.
+              They run from Derby Rd, Portsmouth, Buckland United Reformed Church. They also have a small farm
+              holding in Catherington Lane where some of their attendees go to clean out and look after the chickens, goat,
+              lamas and ducks.
+              My daughter goes to the farm one day a week and loves going there.
+              A donation would help to keep the farm and workshops going.
+            </li>
+            <li>Chairperson's Charity Award (£250) - this will go to Portsmouth Foodbank</li>
+          </ol>
+        </li>
+        <li>Club Awards
+          <ol>
+            <li>Ian Morrison Award for the member who has attended most HRRL & SCCL races this year</li>
+            <li>Most Improved Male and Female runners</li>
+            <li>Chairperson's Award</li>
+            <li>Outstanding Achievement Award</li>
+            <li>Joggers' Jogger (voted on at the AGM) Nominations are:
+              <ol>
+                <li>Paul and Pauline Jeffrey
+                  <blockquote>
+                    They can regularly be found representing PJC at races both locally and further afield. They are super
+                    team players, always supporting others at HRRL races. They write regular posts on our Facebook page
+                    encouraging other Joggers. In the past year they also took on getting the PJC Malta Marathon trip back up
+                    and running, and are already planning next year!
+                  </blockquote>
+                </li>
+                <li>Sue Clarke
+                  <blockquote>
+                    She is always in the mix of things helping the club, either on committee stuff, race directing, group
+                    leading, and volunteering wherever she is needed. She does all of this not because she feels it's her duty,
+                    she does it because it feels right to do it. And she likes to keep her wellness bucket nice and full.
+                  </blockquote>
+                  <blockquote>
+                    She does so much for PJC that I'm not sure she gets the recognition for - she's an RD for the Summer XC,
+                    a run leader, she helps organise the mince pie run, and she has taken on the roles of welfare officer and
+                    vice-chair. On top of that she is always so welcoming and happy to help our members, new ones and old
+                    ones.
+                  </blockquote>
+                </li>
+                <li>Sue Hyson
+                  <blockquote>
+                    Sue works tirelessly behind the scenes, keeping PJC running. It is Sue who organises the committee and
+                    communicates with EA to make sure we are always meeting the high standards required. Not only is she
+                    the queen of organisation, she leads one of our groups and helps run the C25K programme. She
+                    volunteers a significant proportion of her time to PJC, and that should definitely be recognised!
+                  </blockquote>
+                  <blockquote>
+                    Sue does an incredible amount of work behind the scenes, keeping things running smoothly with her
+                    dedication to the club's administration. She leads the Next Step group with energy and enthusiasm, and
+                    without fail, takes on the Couch to 5K group every time a course is run. Sue is a fantastic ambassador for
+                    Portsmouth Joggers and a truly valued member of the club.
+                  </blockquote>
+                </li>
+                <li>Richard Sullivan
+                  <blockquote>
+                    Richard has recently joined the website support team and has spent a considerable amount of time
+                    working on the site and adding new pages to make it as attractive and professional as he can. He has also
+                    set up a Strava group for PJC and uses this to advertise what each group is doing each club night. He's also
+                    a group leader and encourages his group members to be the best they can
+                  </blockquote>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>Committee Elections
+          <p>Nominations for the 2024/25 committee are:
+          <ol>
+            <li>Chair: Kate Lewis. Proposed by Sue Clarke, seconded by Chris Ellis</li>
+            <li>Treasurer: Gary Lamb. Proposed by Sue Hyson, seconded by Steve Hyson</li>
+            <li>Secretary: Sue Hyson. Proposed by Kate Lewis, seconded by Ally Smith</li>
+            <li>Vice Chair: Sue Clarke. Proposed by Chris Ellis, seconded by Celia Oxley</li>
+          </ol>
+          <p>Committee Members:
+          <ol start="5">
+            <li>Celia Oxley. Proposed by Ally Smith, seconded by Sarah Stone</li>
+            <li>Steve Hyson. Proposed by Sarah Stone, seconded by Sue Clarke</li>
+            <li>Ally Smith. Proposed by Steve Hyson, seconded by Kate Lewis</li>
+            <li>Chris Ellis. Proposed by Gary Lamb, seconded by Sue Hyson</li>
+            <li>Sarah Stone. Proposed by Celia Oxley, seconded by Gary Lamb</li>
+            <li>Paul James. Nominated by Sue Hyson, seconded by Steve Hyson</li>
+            <li>Pete Birch. Nominated by Kate Lewis, seconded by Sue Hyson</li>
+            <li>Tim Le Comte. Nominated by Kate Lewis, seconded by Pete Coote</li>
+          </ol>
+        </li>
+        <li>A.O.B</li>
+      </ol>
+    </nav>
+
+    <p>Following the AGM there will be a Quiz - teams of 6 (prize of £60 for the winning team)</p>
+
+  </article>
+</main>
+
+<footer>
+  <small>&copy; Portsmouth Joggers 2025</small>
+</footer>
+
+<script>
+
+  const agendaList = document.querySelector('nav');
+  agendaList.addEventListener('click', toggler);
+
+  function toggler(event) {
+    let parentLI = event.target.closest('li');
+
+    const dullChildren = parentLI?.querySelectorAll('li:not(.highlight)');
+    if (dullChildren?.length > 0) {
+      dullChildren[0].classList.toggle('highlight');
+    } else {
+      parentLI?.classList.toggle('highlight');
+    }
+  }
+</script>

--- a/members/index.html
+++ b/members/index.html
@@ -26,7 +26,8 @@
     <section>
       <h2>Annual General Meeting - 22nd April 2025</h2>
 
-      <p>Come along to our AGM on Tuesday 22nd April at 7 pm. You can find the Agenda <a href = "PJC.AGM.Agenda.22-4-25.pdf" target="_blank">here</a>.</p>
+      <p>Come along to our AGM on Tuesday 22nd April at 7 pm.
+      <p>Here is the <a href="agm2025.html">Agenda</a> - also available as a <a href = "PJC.AGM.Agenda.22-4-25.pdf" target="_blank">PDF</a> for printing.</p>
 
       <p><strong><mark>Please note a change in venue from previous years.</mark></strong></p>
             


### PR DESCRIPTION
Create a web version of the  AGM Agenda for easy phone viewing without needing a PDF viewer or having to zoom.  Extends #77