### PR TITLE
Early Birds removed from groups

### DIFF
--- a/groups/index.html
+++ b/groups/index.html
@@ -48,7 +48,7 @@
       </div>
       <!-- <a href="/c25k/" id="--c25k">Couch to 5K</a> -->
       <a href="#social" id="--social">Social</a>
-      <a href="#early-birds" id="--early-birds">Early Birds</a>
+      <!--<a href="#early-birds" id="--early-birds">Early Birds</a>-->
       <a href="#next-step" id="--next-step">Next Step</a>
       <a href="#inbetweeners" id="--inbetweeners">Inbetweeners</a>
       <a href="#pace-cadets" id="--pace-cadets">Pace Cadets</a>
@@ -276,7 +276,7 @@
 
     <section id="social">
       <h2>Social Group</h2>
-      <p>The Social Group is led on Tuesdays by Ally Smith and on Thursdays by Celia Oxley.
+      <p>The Social Group is led by Ally Smith and Celia Oxley.
 
       <div class="sidebyside">
         <figure>
@@ -294,12 +294,14 @@
 
       <p>It's an ideal first step for those people who are not quite sure if they are confident enough to move on to the <a href="#nextstep">Next Step</a> after completing <a href="/c25k/">Couch to 5K</a>.
 
-      <p>During the summer months we venture out to explore the beautiful countryside and seafront that we are fortunate enough to live near to. Runs will start at 6:30pm, please refer to the Portsmouth Running Group Facebook page for details each week.
+      <p>During the summer months (June, July, August) we venture out to explore the beautiful countryside and seafront that we are fortunate enough to live near to. Runs will start at 6:30pm, please refer to the Portsmouth Running Group Facebook page for details each week.
 
+      <p>During the rest of the year we run from Lakeside. Tuesday's we run at 7pm and Thursday's we run at 6pm.</p> 
+        
       <p>If you fancy a run/walk or gentle plod with a group of like-minded people then why not come and join us.
     </section>
 
-    <section id="early-birds">
+    <!--<section id="early-birds">
       <figure>
         <img src="mandy.jpg" alt="Mandy" loading="lazy">
         <figcaption>Mandy</figcaption>
@@ -316,7 +318,7 @@
 
       <p>If you occasionally need an earlier run, come and join the early birds, you can be assured of a warm welcome.
    
-      </section>
+      </section>-->
 
     <section id="walking-group">     
       <figure>


### PR DESCRIPTION
Early birds details hidden so that they can be restored if/when needed